### PR TITLE
[Serve] Added deadline awareness

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -36,7 +36,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "linux" ]]; then
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q scipy tensorflow cython==0.29.0 gym opencv-python-headless pyyaml pandas==0.24.2 requests \
     feather-format lxml openpyxl xlrd py-spy setproctitle pytest-timeout networkx tabulate psutil aiohttp \
-    uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures
+    uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures blist
 elif [[ "$PYTHON" == "2.7" ]] && [[ "$platform" == "macosx" ]]; then
   # Install miniconda.
   wget -q https://repo.continuum.io/miniconda/Miniconda2-4.5.4-MacOSX-x86_64.sh -O miniconda.sh -nv
@@ -52,7 +52,7 @@ elif [[ "$PYTHON" == "3.5" ]] && [[ "$platform" == "macosx" ]]; then
   export PATH="$HOME/miniconda/bin:$PATH"
   pip install -q cython==0.29.0 tensorflow gym opencv-python-headless pyyaml pandas==0.24.2 requests \
     feather-format lxml openpyxl xlrd py-spy setproctitle pytest-timeout networkx tabulate psutil aiohttp \
-    uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures
+    uvicorn dataclasses pygments werkzeug kubernetes flask grpcio pytest-sugar pytest-rerunfailures blist
 elif [[ "$LINT" == "1" ]]; then
   sudo apt-get update
   sudo apt-get install -y build-essential curl unzip

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -23,3 +23,4 @@ flask
 uvicorn
 pygments
 werkzeug
+blist

--- a/python/ray/experimental/serve/examples/echo_slo_reverse.py
+++ b/python/ray/experimental/serve/examples/echo_slo_reverse.py
@@ -1,5 +1,5 @@
 """
-Slo [reverse] example of ray.serve module
+SLO [reverse] example of ray.serve module
 """
 
 import time

--- a/python/ray/experimental/serve/examples/echo_slo_reverse.py
+++ b/python/ray/experimental/serve/examples/echo_slo_reverse.py
@@ -34,8 +34,8 @@ time.sleep(2)
 # slo (10 milliseconds deadline) can be specified via http
 slo_ms = 10.0
 print("> [HTTP] Pinging http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms))
-print(requests.get(
-    "http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms)).json())
+print(
+    requests.get("http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms)).json())
 
 # get the handle of the endpoint
 handle = serve.get_handle("my_endpoint")

--- a/python/ray/experimental/serve/examples/echo_slo_reverse.py
+++ b/python/ray/experimental/serve/examples/echo_slo_reverse.py
@@ -1,0 +1,61 @@
+"""
+Slo [reverse] example of ray.serve module
+"""
+
+import time
+
+import requests
+
+import ray
+import ray.experimental.serve as serve
+from ray.experimental.serve.utils import pformat_color_json
+
+# initialize ray serve system.
+# blocking=True will wait for HTTP server to be ready to serve request.
+serve.init(blocking=True)
+
+# an endpoint is associated with an http URL.
+serve.create_endpoint("my_endpoint", "/echo")
+
+# a backend can be a function or class.
+# it can be made to be invoked from web as well as python.
+def echo_v1(flask_request, response="hello from python!"):
+    if serve.context.web:
+        response = flask_request.url
+    return response
+
+serve.create_backend(echo_v1, "echo:v1")
+serve.link("my_endpoint", "echo:v1")
+
+# wait for routing table to get populated
+time.sleep(2)
+
+# slo (10 milliseconds deadline) can be specified via http
+slo_ms = 10.0
+print("> [HTTP] Pinging http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms))
+print(requests.get("http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms)).json())
+
+# get the handle of the endpoint
+handle = serve.get_handle("my_endpoint")
+
+future_list = []
+
+# fire 10 requests with slo's in the (almost) reverse order of the order in which
+# remote procedure call is done
+for r in range(10):
+    slo_ms = 1000 - 100*r
+    response = "hello from request: {} slo: {}".format(r,slo_ms)
+    print("> [REMOTE] Pinging handle.remote(response='{}',slo_ms={})".format(response,slo_ms))
+    # slo can be specified via remote function
+    f = handle.remote(response=response,slo_ms=slo_ms)
+    future_list.append(f)
+
+# get results of queries as they complete
+# should be completed (almost) according to the order of their slo time
+left_futures = future_list
+while left_futures:
+    completed_futures , remaining_futures = ray.wait(left_futures,timeout=0.05)
+    if len(completed_futures) > 0:
+        result = ray.get(completed_futures[0])
+        print(result)
+    left_futures = remaining_futures

--- a/python/ray/experimental/serve/examples/echo_slo_reverse.py
+++ b/python/ray/experimental/serve/examples/echo_slo_reverse.py
@@ -8,7 +8,6 @@ import requests
 
 import ray
 import ray.experimental.serve as serve
-from ray.experimental.serve.utils import pformat_color_json
 
 # initialize ray serve system.
 # blocking=True will wait for HTTP server to be ready to serve request.
@@ -17,12 +16,14 @@ serve.init(blocking=True)
 # an endpoint is associated with an http URL.
 serve.create_endpoint("my_endpoint", "/echo")
 
+
 # a backend can be a function or class.
 # it can be made to be invoked from web as well as python.
 def echo_v1(flask_request, response="hello from python!"):
     if serve.context.web:
         response = flask_request.url
     return response
+
 
 serve.create_backend(echo_v1, "echo:v1")
 serve.link("my_endpoint", "echo:v1")
@@ -33,28 +34,30 @@ time.sleep(2)
 # slo (10 milliseconds deadline) can be specified via http
 slo_ms = 10.0
 print("> [HTTP] Pinging http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms))
-print(requests.get("http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms)).json())
+print(requests.get(
+    "http://127.0.0.1:8000/echo?slo_ms={}".format(slo_ms)).json())
 
 # get the handle of the endpoint
 handle = serve.get_handle("my_endpoint")
 
 future_list = []
 
-# fire 10 requests with slo's in the (almost) reverse order of the order in which
-# remote procedure call is done
+# fire 10 requests with slo's in the (almost) reverse order of the order in
+# which remote procedure call is done
 for r in range(10):
-    slo_ms = 1000 - 100*r
-    response = "hello from request: {} slo: {}".format(r,slo_ms)
-    print("> [REMOTE] Pinging handle.remote(response='{}',slo_ms={})".format(response,slo_ms))
+    slo_ms = 1000 - 100 * r
+    response = "hello from request: {} slo: {}".format(r, slo_ms)
+    print("> [REMOTE] Pinging handle.remote(response='{}',slo_ms={})".format(
+        response, slo_ms))
     # slo can be specified via remote function
-    f = handle.remote(response=response,slo_ms=slo_ms)
+    f = handle.remote(response=response, slo_ms=slo_ms)
     future_list.append(f)
 
 # get results of queries as they complete
 # should be completed (almost) according to the order of their slo time
 left_futures = future_list
 while left_futures:
-    completed_futures , remaining_futures = ray.wait(left_futures,timeout=0.05)
+    completed_futures, remaining_futures = ray.wait(left_futures, timeout=0.05)
     if len(completed_futures) > 0:
         result = ray.get(completed_futures[0])
         print(result)

--- a/python/ray/experimental/serve/handle.py
+++ b/python/ray/experimental/serve/handle.py
@@ -36,12 +36,22 @@ class RayServeHandle:
             raise RayServeException(
                 "handle.remote must be invoked with keyword arguments.")
 
+        # get slo_ms before enqueuing the query
+        request_slo_ms = kwargs.pop('slo_ms',None)
+        if request_slo_ms is not None:
+            try:
+                request_slo_ms = float(request_slo_ms)
+                if request_slo_ms < 0:
+                    raise ValueError("Request SLO must be positive, it is {}".format(request_slo_ms))
+            except ValueError as e:
+                raise RayServeException(str(e))
+              
         result_object_id_bytes = ray.get(
             self.router_handle.enqueue_request.remote(
                 service=self.endpoint_name,
                 request_args=(),
                 request_kwargs=kwargs,
-                request_context=TaskContext.Python))
+                request_context=TaskContext.Python,request_slo_ms=request_slo_ms))
         return ray.ObjectID(result_object_id_bytes)
 
     def get_traffic_policy(self):

--- a/python/ray/experimental/serve/handle.py
+++ b/python/ray/experimental/serve/handle.py
@@ -37,21 +37,24 @@ class RayServeHandle:
                 "handle.remote must be invoked with keyword arguments.")
 
         # get slo_ms before enqueuing the query
-        request_slo_ms = kwargs.pop('slo_ms',None)
+        request_slo_ms = kwargs.pop("slo_ms", None)
         if request_slo_ms is not None:
             try:
                 request_slo_ms = float(request_slo_ms)
                 if request_slo_ms < 0:
-                    raise ValueError("Request SLO must be positive, it is {}".format(request_slo_ms))
+                    raise ValueError(
+                        "Request SLO must be positive, it is {}".format(
+                            request_slo_ms))
             except ValueError as e:
                 raise RayServeException(str(e))
-              
+
         result_object_id_bytes = ray.get(
             self.router_handle.enqueue_request.remote(
                 service=self.endpoint_name,
                 request_args=(),
                 request_kwargs=kwargs,
-                request_context=TaskContext.Python,request_slo_ms=request_slo_ms))
+                request_context=TaskContext.Python,
+                request_slo_ms=request_slo_ms))
         return ray.ObjectID(result_object_id_bytes)
 
     def get_traffic_policy(self):

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -24,7 +24,8 @@ class Query:
         else:
             self.result_object_id = result_object_id
 
-        # adding SLO (time taken to be completed)
+        # Service level objective in milliseconds. This is expected to be the
+        # absolute time since unix epoch.
         self.request_slo_ms = request_slo_ms
 
     # adding comparator fn for maintaining an
@@ -86,6 +87,12 @@ class CentralizedQueues:
 
         # backend_name -> worker payload queue
         # using blist sortedlist for deadline awareness
+        # blist is chosen because:  
+        # 1. pop operation should be O(1) (amortized) 
+        #    (helpful even for batched pop)
+        # 2. There should not be significant overhead in 
+        #    maintaining the sorted list.
+        # 3. The blist implementation is fast and uses C extensions.
         self.buffer_queues = defaultdict(sortedlist)
 
     def is_ready(self):

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -87,10 +87,10 @@ class CentralizedQueues:
 
         # backend_name -> worker payload queue
         # using blist sortedlist for deadline awareness
-        # blist is chosen because:  
-        # 1. pop operation should be O(1) (amortized) 
+        # blist is chosen because:
+        # 1. pop operation should be O(1) (amortized)
         #    (helpful even for batched pop)
-        # 2. There should not be significant overhead in 
+        # 2. There should not be significant overhead in
         #    maintaining the sorted list.
         # 3. The blist implementation is fast and uses C extensions.
         self.buffer_queues = defaultdict(sortedlist)

--- a/python/ray/experimental/serve/queues.py
+++ b/python/ray/experimental/serve/queues.py
@@ -7,6 +7,7 @@ from ray.experimental.serve.utils import logger
 from blist import sortedlist
 import time
 
+
 class Query:
     def __init__(self,
                  request_args,
@@ -26,7 +27,7 @@ class Query:
         # adding SLO (time taken to be completed)
         self.request_slo_ms = request_slo_ms
 
-    # adding comparator fn for maintaining a 
+    # adding comparator fn for maintaining an
     # ascending order sorted list w.r.t request_slo_ms
     def __lt__(self, other):
         return self.request_slo_ms < other.request_slo_ms
@@ -99,19 +100,23 @@ class CentralizedQueues:
             for backend_name, queue in self.buffer_queues.items()
         }
 
-    # request_slo_ms is time specified in milliseconds till which the 
+    # request_slo_ms is time specified in milliseconds till which the
     # answer of the query should be calculated
-    def enqueue_request(self, service, request_args, request_kwargs,
-                        request_context,request_slo_ms=None):
+    def enqueue_request(self,
+                        service,
+                        request_args,
+                        request_kwargs,
+                        request_context,
+                        request_slo_ms=None):
         if request_slo_ms is None:
             # if request_slo_ms is not specified then set it to a high level
             request_slo_ms = 1e9
-        
+
         # add wall clock time to specify the deadline for completion of query
         # this also assures FIFO behaviour if request_slo_ms is not specified
-        request_slo_ms += (time.time()*1000)
-        query = Query(request_args, request_kwargs, 
-            request_context, request_slo_ms)
+        request_slo_ms += (time.time() * 1000)
+        query = Query(request_args, request_kwargs, request_context,
+                      request_slo_ms)
         self.queues[service].append(query)
         self.flush()
         return query.result_object_id.binary()
@@ -169,7 +174,7 @@ class CentralizedQueues:
                 backend_names = list(self.traffic[service].keys())
                 backend_weights = list(self.traffic[service].values())
                 # TODO(alind): is random choice good for deadline awareness?
-                # putting query in a buffer of a non available backend may 
+                # putting query in a buffer of a non available backend may
                 # not be good
                 chosen_backend = np.random.choice(
                     backend_names, p=backend_weights).squeeze()

--- a/python/ray/experimental/serve/server.py
+++ b/python/ray/experimental/serve/server.py
@@ -131,7 +131,7 @@ class HTTPProxy:
         # get slo_ms before enqueuing the query 
         query_string = scope["query_string"].decode("ascii")
         query_kwargs = parse_qs(query_string)
-        request_slo_ms =  query_kwargs.pop('slo_ms',None)
+        request_slo_ms =  query_kwargs.pop("slo_ms",None)
         if request_slo_ms is not None:
             try:
                 if len(request_slo_ms) != 1:

--- a/python/ray/experimental/serve/server.py
+++ b/python/ray/experimental/serve/server.py
@@ -8,7 +8,7 @@ from ray.experimental.async_api import _async_init, as_future
 from ray.experimental.serve.constants import HTTP_ROUTER_CHECKER_INTERVAL_S
 from ray.experimental.serve.context import TaskContext
 from ray.experimental.serve.utils import BytesEncoder
-
+from urllib.parse import parse_qs
 
 class JSONResponse:
     """ASGI compliant response class.
@@ -128,13 +128,29 @@ class HTTPProxy:
         endpoint_name = self.route_table_cache[current_path]
         http_body_bytes = await self.receive_http_body(scope, receive, send)
 
+        # get slo_ms before enqueuing the query 
+        query_string = scope["query_string"].decode("ascii")
+        query_kwargs = parse_qs(query_string)
+        request_slo_ms =  query_kwargs.pop('slo_ms',None)
+        if request_slo_ms is not None:
+            try:
+                if len(request_slo_ms) != 1:
+                    raise ValueError("Multiple SLO specified, please specific only one.")
+                request_slo_ms = request_slo_ms[0]
+                request_slo_ms = float(request_slo_ms)
+                if request_slo_ms < 0:
+                    raise ValueError("Request SLO must be positive, it is {}".format(request_slo_ms))
+            except ValueError as e:
+                await JSONResponse({"error": str(e)})(scope, receive, send)
+                return
+
         result_object_id_bytes = await as_future(
             self.serve_global_state.init_or_get_router()
             .enqueue_request.remote(
                 service=endpoint_name,
                 request_args=(scope, http_body_bytes),
                 request_kwargs=dict(),
-                request_context=TaskContext.Web))
+                request_context=TaskContext.Web,request_slo_ms=request_slo_ms))
 
         result = await as_future(ray.ObjectID(result_object_id_bytes))
 

--- a/python/ray/experimental/serve/server.py
+++ b/python/ray/experimental/serve/server.py
@@ -10,6 +10,7 @@ from ray.experimental.serve.context import TaskContext
 from ray.experimental.serve.utils import BytesEncoder
 from urllib.parse import parse_qs
 
+
 class JSONResponse:
     """ASGI compliant response class.
 
@@ -128,18 +129,21 @@ class HTTPProxy:
         endpoint_name = self.route_table_cache[current_path]
         http_body_bytes = await self.receive_http_body(scope, receive, send)
 
-        # get slo_ms before enqueuing the query 
+        # get slo_ms before enqueuing the query
         query_string = scope["query_string"].decode("ascii")
         query_kwargs = parse_qs(query_string)
-        request_slo_ms =  query_kwargs.pop("slo_ms",None)
+        request_slo_ms = query_kwargs.pop("slo_ms", None)
         if request_slo_ms is not None:
             try:
                 if len(request_slo_ms) != 1:
-                    raise ValueError("Multiple SLO specified, please specific only one.")
+                    raise ValueError(
+                        "Multiple SLO specified, please specific only one.")
                 request_slo_ms = request_slo_ms[0]
                 request_slo_ms = float(request_slo_ms)
                 if request_slo_ms < 0:
-                    raise ValueError("Request SLO must be positive, it is {}".format(request_slo_ms))
+                    raise ValueError(
+                        "Request SLO must be positive, it is {}".format(
+                            request_slo_ms))
             except ValueError as e:
                 await JSONResponse({"error": str(e)})(scope, receive, send)
                 return
@@ -150,7 +154,8 @@ class HTTPProxy:
                 service=endpoint_name,
                 request_args=(scope, http_body_bytes),
                 request_kwargs=dict(),
-                request_context=TaskContext.Web,request_slo_ms=request_slo_ms))
+                request_context=TaskContext.Web,
+                request_slo_ms=request_slo_ms))
 
         result = await as_future(ray.ObjectID(result_object_id_bytes))
 

--- a/python/ray/experimental/serve/tests/test_queue.py
+++ b/python/ray/experimental/serve/tests/test_queue.py
@@ -2,6 +2,7 @@ import pytest
 import ray
 from ray.experimental.serve.queues import CentralizedQueues
 
+
 @pytest.fixture(scope="session")
 def task_runner_mock_actor():
     @ray.remote
@@ -32,17 +33,18 @@ def test_single_prod_cons_queue(serve_instance, task_runner_mock_actor):
     ray.worker.global_worker.put_object(2, got_work.result_object_id)
     assert ray.get(ray.ObjectID(result_object_id)) == 2
 
+
 def test_slo(serve_instance, task_runner_mock_actor):
     q = CentralizedQueues()
     q.link("svc", "backend")
 
     for i in range(10):
-        slo_ms = 1000 - 100*i
-        q.enqueue_request("svc", i, "kwargs", None,request_slo_ms=slo_ms)
+        slo_ms = 1000 - 100 * i
+        q.enqueue_request("svc", i, "kwargs", None, request_slo_ms=slo_ms)
     for i in range(10):
         q.dequeue_request("backend", task_runner_mock_actor)
         got_work = ray.get(task_runner_mock_actor.get_recent_call.remote())
-        assert got_work.request_args == (9-i)
+        assert got_work.request_args == (9 - i)
 
 
 def test_alter_backend(serve_instance, task_runner_mock_actor):

--- a/python/ray/experimental/serve/tests/test_queue.py
+++ b/python/ray/experimental/serve/tests/test_queue.py
@@ -2,7 +2,6 @@ import pytest
 import ray
 from ray.experimental.serve.queues import CentralizedQueues
 
-
 @pytest.fixture(scope="session")
 def task_runner_mock_actor():
     @ray.remote
@@ -32,6 +31,18 @@ def test_single_prod_cons_queue(serve_instance, task_runner_mock_actor):
 
     ray.worker.global_worker.put_object(2, got_work.result_object_id)
     assert ray.get(ray.ObjectID(result_object_id)) == 2
+
+def test_slo(serve_instance, task_runner_mock_actor):
+    q = CentralizedQueues()
+    q.link("svc", "backend")
+
+    for i in range(10):
+        slo_ms = 1000 - 100*i
+        q.enqueue_request("svc", i, "kwargs", None,request_slo_ms=slo_ms)
+    for i in range(10):
+        q.dequeue_request("backend", task_runner_mock_actor)
+        got_work = ray.get(task_runner_mock_actor.get_recent_call.remote())
+        assert got_work.request_args == (9-i)
 
 
 def test_alter_backend(serve_instance, task_runner_mock_actor):

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,7 +79,7 @@ extras = {
     ],
     "debug": ["psutil", "setproctitle", "py-spy >= 0.2.0"],
     "dashboard": ["aiohttp", "google", "grpcio", "psutil", "setproctitle"],
-    "serve": ["uvicorn", "pygments", "werkzeug", "flask", "pandas","blist"],
+    "serve": ["uvicorn", "pygments", "werkzeug", "flask", "pandas", "blist"],
     "tune": ["tabulate"],
 }
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -79,7 +79,7 @@ extras = {
     ],
     "debug": ["psutil", "setproctitle", "py-spy >= 0.2.0"],
     "dashboard": ["aiohttp", "google", "grpcio", "psutil", "setproctitle"],
-    "serve": ["uvicorn", "pygments", "werkzeug", "flask", "pandas"],
+    "serve": ["uvicorn", "pygments", "werkzeug", "flask", "pandas","blist"],
     "tune": ["tabulate"],
 }
 


### PR DESCRIPTION
1. Added deadline awareness while enqueuing a query
2. Using Blist sorted-list implementation (ascending order) to get queries according to their specified deadlines [buffer_queues]
3. Exposed slo_ms via handle/http request
4. Added slo example 
5. The queries in example will be executed in almost the opposite order of which they are fired
6. Added slo pytest
7. Added check for slo_ms to not be negative

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
